### PR TITLE
fix: serve pdfjs worker from /assets so it loads in prod

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -27,6 +27,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "pdf.worker.min.mjs",
+                "input": "node_modules/pdfjs-dist/build/",
+                "output": "/assets/"
               }
             ],
             "styles": [

--- a/frontend/src/app/components/orders/bulk-upload/bulk-upload.ts
+++ b/frontend/src/app/components/orders/bulk-upload/bulk-upload.ts
@@ -204,11 +204,7 @@ export class BulkUploadComponent {
 
     private async extractTextFromPdf(arrayBuffer: ArrayBuffer): Promise<string> {
         const pdfjsLib = await import('pdfjs-dist');
-        // Resolve through the bundler so the worker always matches the API version.
-        pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
-            'pdfjs-dist/build/pdf.worker.min.mjs',
-            import.meta.url,
-        ).toString();
+        pdfjsLib.GlobalWorkerOptions.workerSrc = 'assets/pdf.worker.min.mjs';
 
         const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
         const lines: string[] = [];

--- a/frontend/src/app/components/orders/pdf-import/pdf-import.ts
+++ b/frontend/src/app/components/orders/pdf-import/pdf-import.ts
@@ -141,11 +141,7 @@ export class PdfImportComponent {
 
     private async extractTextFromPdf(arrayBuffer: ArrayBuffer): Promise<string> {
         const pdfjsLib = await import('pdfjs-dist');
-        // Resolve through the bundler so the worker always matches the API version.
-        pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
-            'pdfjs-dist/build/pdf.worker.min.mjs',
-            import.meta.url,
-        ).toString();
+        pdfjsLib.GlobalWorkerOptions.workerSrc = 'assets/pdf.worker.min.mjs';
 
         const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
         const lines: string[] = [];


### PR DESCRIPTION
esbuild does not transform new URL() when the first argument is a bare module specifier, so the previous fix resolved the worker against the page origin and 404'd. Copy the worker from node_modules at build time and point workerSrc back at /assets/pdf.worker.min.mjs — the node_modules source guarantees the worker stays in sync with the imported pdfjs API version.